### PR TITLE
Hide each of the fields Masterwork, Mod if their value is n/a

### DIFF
--- a/lib/gunsmith/slack_bot.rb
+++ b/lib/gunsmith/slack_bot.rb
@@ -296,10 +296,11 @@ module Gunsmith
           short: true
         )
 
+        description = results[:item][:mod] ? results[:item][:mod][:name].to_s : 'n/a'
         attachment_fields.push(
           title: 'Mod',
           ### TODO -- get rid of description?
-          value: results[:item][:mod] ? results[:item][:mod][:name].to_s : 'n/a',
+          value: description,
           short: true
         )
       end

--- a/lib/gunsmith/slack_bot.rb
+++ b/lib/gunsmith/slack_bot.rb
@@ -281,7 +281,7 @@ module Gunsmith
           short: true
         )
       else
-        # Masterwork / Mod
+        # Masterwork
         masterwork = 'n/a'
         if results[:item][:masterwork]
           if results&.dig(:item, :masterwork, :affected_stat)
@@ -290,19 +290,26 @@ module Gunsmith
             masterwork = 'Yes'
           end
         end
-        attachment_fields.push(
-          title: 'Masterwork',
-          value: masterwork,
-          short: true
-        )
 
+        if masterwork != 'n/a':
+          attachment_fields.push(
+            title: 'Masterwork',
+            value: masterwork,
+            short: true
+          )
+        end
+
+        # Mod
         description = results[:item][:mod] ? results[:item][:mod][:name].to_s : 'n/a'
-        attachment_fields.push(
-          title: 'Mod',
-          ### TODO -- get rid of description?
-          value: description,
-          short: true
-        )
+
+        if description != 'n/a':
+          attachment_fields.push(
+            title: 'Mod',
+            ### TODO -- get rid of description?
+            value: description,
+            short: true
+          )
+        end
       end
 
       # Stats


### PR DESCRIPTION
For things where the Masterwork or Mod value is n/a, skip showing that column. This _should_ result in the bot results for exotics no longer including the 'MW/Mod' pair of values in the bot's Slack output.